### PR TITLE
Allow support for installing firefox via the api

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ for multiple platforms.
 Install the latest version of Firefox.
 
 ```ruby
-firefox_package 'latest'
+firefox_package 'firefox-latest'
 ```
 
 Configure a 24 hour splay to reduce egress HTTPS requests to Mozilla servers.
 ```ruby
-firefox_package 'latest-esr' do
+firefox_package 'firefox-esr-latest' do
   splay 84600
 end
 ```
 
-* `version`   - Version of Firefox to install. Named versions, such as `latest`, `latest-esr`, `latest-prior-esr`, `latest-beta` are all valid. *(name_attribute)*
+* `version`   - Version of Firefox to install. Named versions, such as `firefox-latest`, `firefox-esr-latest`  are all valid. *(name_attribute)*
 * `checksum`  - SHA256 Checksum of the file. Not required.
 * `uri`       - HTTPS uri to obtain the installer/archive. Defaults to: `https://download-installer.cdn.mozilla.net/pub/firefox/releases`
 * `language`  - Language desired. Defaults to: `en-US`

--- a/test/cookbooks/firefox_package_test/recipes/default.rb
+++ b/test/cookbooks/firefox_package_test/recipes/default.rb
@@ -2,8 +2,8 @@
 include_recipe 'apt' if platform_family?('debian')
 
 {
-  'latest-esr' => [ '/usr/bin/firefox-latest-esr' ],
-  'latest' => [ '/usr/bin/firefox-latest' ],
+  'firefox-esr-latest' => [ '/usr/bin/firefox-esr-latest' ],
+  'firefox-latest' => [ '/usr/bin/firefox-latest' ],
   '37.0' => [ '/usr/bin/firefox-37.0' ]
 }.map do |version, linkto|
   firefox_package version do


### PR DESCRIPTION
#### Description
The firefox cookbook no longer allows pulling latest or esr latest versions via the old method and now requires an API call.  This patch adds support.

#### Verification
- [x] Perform a code review
- [x] Verify you can run kitchen against at least 14.04

After this is completed, notify me and I will:
- delete the old version of the cookbook (on rapid7-cookbooks)
- bump this version 
- push this to chef for further testing and deployment