### PR TITLE
Upgrade to poise 2.5

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,6 +1,7 @@
 ---
 driver:
   name: docker
+  use_sudo: false
 
 provisioner:
   name: chef_zero
@@ -9,7 +10,6 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  - name: ubuntu-12.04
   - name: centos-6
   - name: windows-2012r2
     driver:

--- a/libraries/firefox_package.rb
+++ b/libraries/firefox_package.rb
@@ -220,7 +220,7 @@ module FirefoxPackage
             windows_installer(cached_file, new_resource.version,
                               new_resource.language, :install)
           else
-            package %w{libasound2 libgtk2.0-0 libdbus-glib-1-2 libxt6}
+            package %w{libasound2 libgtk2.0-0 libgtk-3-0 libdbus-glib-1-2 libxt6 libx11-xcb-dev}
 
             explode_tarball(cached_file, new_resource.path)
             node.set['firefox_package']['firefox']["#{new_resource.version}"]["#{new_resource.language}"] = new_resource.path.to_s

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email 'r7_re@rapid7.com'
 license          'Apache 2.0'
 description      'Installs/Configures firefox_package'
 long_description 'Installs/Configures firefox_package'
-version          '0.5.0'
+version          '0.5.1'
 
 supports 'windows'
 supports 'ubuntu'
 
-depends 'poise', '~> 2.3.2'
+depends 'poise', '~> 2.5.0'
 depends 'windows'
 depends 'build-essential'

--- a/test/cookbooks/firefox_package_test/recipes/default_controls.rb
+++ b/test/cookbooks/firefox_package_test/recipes/default_controls.rb
@@ -1,22 +1,22 @@
 control_group 'Firefox Installation' do
   if ['debian', 'ubuntu'].include?(os[:family])
     control 'latest-esr' do
-      subject(:latest_esr) { command('/opt/firefox/latest-esr_en-US/firefox --version') }
+      subject(:latest_esr) { command('/opt/firefox/firefox-esr-latest_en-US/firefox --version') }
       it 'is installed and symlinked' do
-        expect(file('/usr/bin/firefox-latest-esr')).to be_symlink
-        expect(file('/usr/bin/firefox-latest-esr')).to be_linked_to('/opt/firefox/latest-esr_en-US/firefox')
-        expect(file('/opt/firefox/latest-esr_en-US/firefox')).to be_executable
+        expect(file('/usr/bin/firefox-esr-latest')).to be_symlink
+        expect(file('/usr/bin/firefox-esr-latest')).to be_linked_to('/opt/firefox/firefox-esr-latest_en-US/firefox')
+        expect(file('/opt/firefox/firefox-esr-latest_en-US/firefox')).to be_executable
         expect(latest_esr.exit_status).to eq(0)
       end
     end
 
     control 'latest' do
-      subject(:latest) { command('/opt/firefox/latest_en-US/firefox --version') }
+      subject(:latest) { command('/opt/firefox/firefox-latest_en-US/firefox --version') }
 
       it 'is installed and symlinked' do
         expect(file('/usr/bin/firefox-latest')).to be_symlink
-        expect(file('/usr/bin/firefox-latest')).to be_linked_to('/opt/firefox/latest_en-US/firefox')
-        expect(file('/opt/firefox/latest_en-US/firefox')).to be_executable
+        expect(file('/usr/bin/firefox-latest')).to be_linked_to('/opt/firefox/firefox-latest_en-US/firefox')
+        expect(file('/opt/firefox/firefox-latest_en-US/firefox')).to be_executable
       end
 
       it 'is functional when invoked' do
@@ -25,12 +25,12 @@ control_group 'Firefox Installation' do
     end
 
     control '37.0' do
-      subject(:specified_version) { command('/opt/firefox/37.0_en-US/firefox --version') }
+      subject(:specified_version) { command('/opt/firefox/firefox-37.0_en-US/firefox --version') }
 
       it 'is installed and symlinked' do
         expect(file('/usr/bin/firefox-37.0')).to be_symlink
-        expect(file('/usr/bin/firefox-37.0')).to be_linked_to('/opt/firefox/37.0_en-US/firefox')
-        expect(file('/opt/firefox/37.0_en-US/firefox')).to be_executable
+        expect(file('/usr/bin/firefox-37.0')).to be_linked_to('/opt/firefox/firefox-37.0_en-US/firefox')
+        expect(file('/opt/firefox/firefox-37.0_en-US/firefox')).to be_executable
       end
 
       it 'is functional when invoked' do
@@ -43,7 +43,7 @@ control_group 'Firefox Installation' do
     end
 
     control 'Upgrade 37.0 to 38.0' do
-      subject(:upgraded_version) { command('/opt/firefox/38.0_en-US/firefox --version') }
+      subject(:upgraded_version) { command('/opt/firefox/firefox-38.0_en-US/firefox --version') }
 
       it 'is functional when invoked after upgrade' do
         expect(upgraded_version.exit_status).to eq(0)


### PR DESCRIPTION
We need to get up to poise 2.5 for compatibility with recent poise-python based cookbooks.

This PR:
- upgrades to poise 2.5
- drops support for ubuntu 12.04 (wasn't actually working to begin with... required apt packages not available)
- fixes test kitchen audit tests